### PR TITLE
fix submit call inside a form

### DIFF
--- a/src/views/file-upload.php
+++ b/src/views/file-upload.php
@@ -31,7 +31,7 @@ $this->registerJs($js, yii\web\View::POS_READY);
             <div class="modal-body"></div>
             <div class="modal-footer">
                 <div class="modal-info"></div>
-                <button id="cropImage">Сохранить</button>
+                <button id="cropImage" type="button">Сохранить</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
При использовании внутри `<form>`, отправка формы тригерит клик на кнопке `#cropImage`, т.к. без указанного типа, она принимается за `submit`
Клик по кнопке происходит без необходимой инициализации, из-за чего скрипт падает с ошибкой

```
file-upload.js:339 Uncaught TypeError: Cannot read property 'getCroppedCanvas' of undefined at HTMLButtonElement.applyCropper (file-upload.js:339)
```